### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/kand-ta/kand/security/code-scanning/22](https://github.com/kand-ta/kand/security/code-scanning/22)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Since the workflow involves checking out the repository and publishing to crates.io, it needs `contents: read` for accessing the repository contents and `packages: write` for publishing the package. These permissions will be explicitly set to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
