### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/kand-ta/kand/security/code-scanning/21](https://github.com/kand-ta/kand/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves building and testing Rust code, it does not require write permissions. We will set the `contents` permission to `read`, which is the minimal permission required for the `actions/checkout` step to function correctly. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to complete the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
